### PR TITLE
Update Python path for install_munki_optional.py

### DIFF
--- a/install_munki_optional.py
+++ b/install_munki_optional.py
@@ -1,4 +1,4 @@
-#!/usr/local/munki/Python.framework/Versions/Current/bin/python3
+#!/usr/local/munki/munki-python
 
 '''
 Script to be called from Jamf Self-Service policy to mark a Munki optional


### PR DESCRIPTION
Munki no longer uses `/usr/local/munki/python`, so this PR updates for the new path.